### PR TITLE
Implement terminal CSI reporting of window and cell pixel size

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalSession.java
@@ -96,12 +96,12 @@ public final class TerminalSession extends TerminalOutput {
     }
 
     /** Inform the attached pty of the new size and reflow or initialize the emulator. */
-    public void updateSize(int columns, int rows, int fontWidth, int fontHeight) {
+    public void updateSize(int columns, int rows, int cellWidthPixels, int cellHeightPixels) {
         if (mEmulator == null) {
-            initializeEmulator(columns, rows, fontWidth, fontHeight);
+            initializeEmulator(columns, rows, cellWidthPixels, cellHeightPixels);
         } else {
-            JNI.setPtyWindowSize(mTerminalFileDescriptor, rows, columns, fontWidth, fontHeight);
-            mEmulator.resize(columns, rows);
+            JNI.setPtyWindowSize(mTerminalFileDescriptor, rows, columns, cellWidthPixels, cellHeightPixels);
+            mEmulator.resize(columns, rows, cellWidthPixels, cellHeightPixels);
         }
     }
 
@@ -116,11 +116,11 @@ public final class TerminalSession extends TerminalOutput {
      * @param columns The number of columns in the terminal window.
      * @param rows    The number of rows in the terminal window.
      */
-    public void initializeEmulator(int columns, int rows, int cellWidth, int cellHeight) {
-        mEmulator = new TerminalEmulator(this, columns, rows, mTranscriptRows, mClient);
+    public void initializeEmulator(int columns, int rows, int cellWidthPixels, int cellHeightPixels) {
+        mEmulator = new TerminalEmulator(this, columns, rows, cellWidthPixels, cellHeightPixels, mTranscriptRows, mClient);
 
         int[] processId = new int[1];
-        mTerminalFileDescriptor = JNI.createSubprocess(mExecutablePath, mCwd, mArgs, mEnv, processId, rows, columns, cellWidth, cellHeight);
+        mTerminalFileDescriptor = JNI.createSubprocess(mExecutablePath, mCwd, mArgs, mEnv, processId, rows, columns, cellWidthPixels, cellHeightPixels);
         mProcessSpawnedTimeMillis = System.currentTimeMillis();
         mShellPid = processId[0];
 

--- a/terminal-emulator/src/test/java/android/util/Base64.java
+++ b/terminal-emulator/src/test/java/android/util/Base64.java
@@ -1,0 +1,18 @@
+package android.util;
+
+public class Base64 {
+
+    public static String encodeToString(byte[] input, int flags) {
+        if (flags != 0) {
+            throw new RuntimeException("Unsupported flags: " + flags);
+        }
+        return java.util.Base64.getEncoder().encodeToString(input);
+    }
+
+    public static byte[] decode(String str, int flags) {
+        if (flags != 0) {
+            throw new RuntimeException("Unsupported flags: " + flags);
+        }
+        return java.util.Base64.getDecoder().decode(str);
+    }
+}

--- a/terminal-emulator/src/test/java/com/termux/terminal/ByteQueueTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/ByteQueueTest.java
@@ -15,7 +15,7 @@ public class ByteQueueTest extends TestCase {
 		}
 	}
 
-	public void testCompleteWrites() throws Exception {
+	public void testCompleteWrites() {
 		ByteQueue q = new ByteQueue(10);
 		assertTrue(q.write(new byte[]{1, 2, 3}, 0, 3));
 
@@ -28,7 +28,7 @@ public class ByteQueueTest extends TestCase {
 		assertArrayEquals(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, arr);
 	}
 
-	public void testQueueWraparound() throws Exception {
+	public void testQueueWraparound() {
 		ByteQueue q = new ByteQueue(10);
 
 		byte[] origArray = new byte[]{1, 2, 3, 4, 5, 6};
@@ -40,13 +40,13 @@ public class ByteQueueTest extends TestCase {
 		}
 	}
 
-	public void testWriteNotesClosing() throws Exception {
+	public void testWriteNotesClosing() {
 		ByteQueue q = new ByteQueue(10);
 		q.close();
 		assertFalse(q.write(new byte[]{1, 2, 3}, 0, 3));
 	}
 
-	public void testReadNonBlocking() throws Exception {
+	public void testReadNonBlocking() {
 		ByteQueue q = new ByteQueue(10);
 		assertEquals(0, q.read(new byte[128], false));
 	}

--- a/terminal-emulator/src/test/java/com/termux/terminal/ControlSequenceIntroducerTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/ControlSequenceIntroducerTest.java
@@ -62,4 +62,24 @@ public class ControlSequenceIntroducerTest extends TerminalTestCase {
 		assertEquals("y\nz", mTerminal.getScreen().getTranscriptText());
 	}
 
+    public void testReportPixelSize() {
+        var columns = 3;
+        var rows = 3;
+        withTerminalSized(columns, rows);
+        var cellWidth = TerminalTest.INITIAL_CELL_WIDTH_PIXELS;
+        var cellHeight = TerminalTest.INITIAL_CELL_HEIGHT_PIXELS;
+        assertEnteringStringGivesResponse("\033[14t", "\033[4;" + (rows*cellHeight) + ";" + (columns*cellWidth) + "t");
+        assertEnteringStringGivesResponse("\033[16t", "\033[6;" + cellHeight + ";" + cellWidth + "t");
+        columns = 23;
+        rows = 33;
+        resize(columns, rows);
+        assertEnteringStringGivesResponse("\033[14t", "\033[4;" + (rows*cellHeight) + ";" + (columns*cellWidth) + "t");
+        assertEnteringStringGivesResponse("\033[16t", "\033[6;" + cellHeight + ";" + cellWidth + "t");
+        cellWidth = 8;
+        cellHeight = 18;
+        mTerminal.resize(columns, rows, cellWidth, cellHeight);
+        assertEnteringStringGivesResponse("\033[14t", "\033[4;" + (rows*cellHeight) + ";" + (columns*cellWidth) + "t");
+        assertEnteringStringGivesResponse("\033[16t", "\033[6;" + cellHeight + ";" + cellWidth + "t");
+    }
+
 }

--- a/terminal-emulator/src/test/java/com/termux/terminal/HistoryTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/HistoryTest.java
@@ -11,10 +11,10 @@ public class HistoryTest extends TerminalTestCase {
 		assertLinesAre("777", "888", "999");
 		assertHistoryStartsWith("666", "555");
 
-		mTerminal.resize(cols, 2);
+		resize(cols, 2);
 		assertHistoryStartsWith("777", "666", "555");
 
-		mTerminal.resize(cols, 3);
+		resize(cols, 3);
 		assertHistoryStartsWith("666", "555");
 	}
 

--- a/terminal-emulator/src/test/java/com/termux/terminal/OperatingSystemControlTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/OperatingSystemControlTest.java
@@ -9,7 +9,7 @@ import java.util.Random;
 /** "ESC ]" is the Operating System Command. */
 public class OperatingSystemControlTest extends TerminalTestCase {
 
-	public void testSetTitle() throws Exception {
+	public void testSetTitle() {
 		List<ChangedTitle> expectedTitleChanges = new ArrayList<>();
 
 		withTerminalSized(10, 10);
@@ -67,7 +67,7 @@ public class OperatingSystemControlTest extends TerminalTestCase {
 		assertEquals(expectedTitleChanges, mOutput.titleChanges);
 	}
 
-	public void testTitleStack() throws Exception {
+	public void testTitleStack() {
 		// echo -ne '\e]0;BEFORE\007' # set title
 		// echo -ne '\e[22t' # push to stack
 		// echo -ne '\e]0;AFTER\007' # set new title
@@ -86,7 +86,7 @@ public class OperatingSystemControlTest extends TerminalTestCase {
 		assertEquals("InitialTitle", mTerminal.getTitle());
 	}
 
-	public void testSetColor() throws Exception {
+	public void testSetColor() {
 		// "OSC 4; $INDEX; $COLORSPEC BEL" => Change color $INDEX to the color specified by $COLORSPEC.
 		withTerminalSized(4, 4).enterString("\033]4;5;#00FF00\007");
 		assertEquals(Integer.toHexString(0xFF00FF00), Integer.toHexString(mTerminal.mColors.mCurrentColors[5]));
@@ -105,7 +105,7 @@ public class OperatingSystemControlTest extends TerminalTestCase {
 			assertEquals("index=" + i, expected[i], mTerminal.mColors.mCurrentColors[i]);
 	}
 
-	public void testResetColor() throws Exception {
+	public void testResetColor() {
 		withTerminalSized(4, 4);
 		int[] initialColors = new int[TextStyle.NUM_INDEXED_COLORS];
 		System.arraycopy(mTerminal.mColors.mCurrentColors, 0, initialColors, 0, initialColors.length);
@@ -137,12 +137,13 @@ public class OperatingSystemControlTest extends TerminalTestCase {
 		assertIndexColorsMatch(TerminalColors.COLOR_SCHEME.mDefaultColors);
 	}
 
-	public void disabledTestSetClipboard() {
-		// Cannot run this as a unit test since Base64 is a android.util class.
+	public void testSetClipboard() {
+        withTerminalSized(4, 4).enterString("\033]4;5;#00FF00\007");
 		enterString("\033]52;c;" + Base64.encodeToString("Hello, world".getBytes(), 0) + "\007");
+        assertEquals(List.of("Hello, world"), mOutput.clipboardPuts);
 	}
 
-	public void testResettingTerminalResetsColor() throws Exception {
+	public void testResettingTerminalResetsColor() {
 		// "OSC 4; $INDEX; $COLORSPEC BEL" => Change color $INDEX to the color specified by $COLORSPEC.
 		withTerminalSized(4, 4).enterString("\033]4;5;#00FF00\007");
 		enterString("\033]4;5;#00FFAB\007").assertColor(5, 0xFF00FFAB);

--- a/terminal-emulator/src/test/java/com/termux/terminal/ResizeTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/ResizeTest.java
@@ -72,11 +72,11 @@ public class ResizeTest extends TerminalTestCase {
 			enterString("\r\n");
 		}
 		assertLinesAre("998       ", "999       ", "          ");
-		mTerminal.resize(cols, 2);
+		resize(cols, 2);
 		assertLinesAre("999       ", "          ");
-		mTerminal.resize(cols, 5);
+		resize(cols, 5);
 		assertLinesAre("996       ", "997       ", "998       ", "999       ", "          ");
-		mTerminal.resize(cols, rows);
+		resize(cols, rows);
 		assertLinesAre("998       ", "999       ", "          ");
 	}
 

--- a/terminal-emulator/src/test/java/com/termux/terminal/TerminalTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/TerminalTest.java
@@ -1,15 +1,13 @@
 package com.termux.terminal;
 
-import java.io.UnsupportedEncodingException;
-
 public class TerminalTest extends TerminalTestCase {
 
-	public void testCursorPositioning() throws Exception {
+	public void testCursorPositioning() {
 		withTerminalSized(10, 10).placeCursorAndAssert(1, 2).placeCursorAndAssert(3, 5).placeCursorAndAssert(2, 2).enterString("A")
 				.assertCursorAt(2, 3);
 	}
 
-	public void testScreen() throws UnsupportedEncodingException {
+	public void testScreen() {
 		withTerminalSized(3, 3);
 		assertLinesAre("   ", "   ", "   ");
 
@@ -40,7 +38,7 @@ public class TerminalTest extends TerminalTestCase {
 		assertForegroundColorAt(2, 0, 115);
 	}
 
-	public void testMouseClick() throws Exception {
+	public void testMouseClick() {
 		withTerminalSized(10, 10);
 		assertFalse(mTerminal.isMouseTrackingActive());
 		enterString("\033[?1000h");
@@ -73,7 +71,7 @@ public class TerminalTest extends TerminalTestCase {
 		assertEquals("\033[<0;10;10m", mOutput.getOutputAndClear());
 	}
 
-	public void testNormalization() throws UnsupportedEncodingException {
+	public void testNormalization() {
 		// int lowerCaseN = 0x006E;
 		// int combiningTilde = 0x0303;
 		// int combined = 0x00F1;
@@ -85,19 +83,19 @@ public class TerminalTest extends TerminalTestCase {
 	}
 
 	/** On "\e[18t" xterm replies with "\e[8;${HEIGHT};${WIDTH}t" */
-	public void testReportTerminalSize() throws Exception {
+	public void testReportTerminalSize() {
 		withTerminalSized(5, 5);
 		assertEnteringStringGivesResponse("\033[18t", "\033[8;5;5t");
 		for (int width = 3; width < 12; width++) {
 			for (int height = 3; height < 12; height++) {
-				mTerminal.resize(width, height);
+                resize(width, height);
 				assertEnteringStringGivesResponse("\033[18t", "\033[8;" + height + ";" + width + "t");
 			}
 		}
 	}
 
 	/** Device Status Report (DSR) and Report Cursor Position (CPR). */
-	public void testDeviceStatusReport() throws Exception {
+	public void testDeviceStatusReport() {
 		withTerminalSized(5, 5);
 		assertEnteringStringGivesResponse("\033[5n", "\033[0n");
 
@@ -109,7 +107,7 @@ public class TerminalTest extends TerminalTestCase {
 	}
 
 	/** Test the cursor shape changes using DECSCUSR. */
-	public void testSetCursorStyle() throws Exception {
+	public void testSetCursorStyle() {
 		withTerminalSized(5, 5);
 		assertEquals(TerminalEmulator.TERMINAL_CURSOR_STYLE_BLOCK, mTerminal.getCursorStyle());
 		enterString("\033[3 q");
@@ -303,7 +301,7 @@ public class TerminalTest extends TerminalTestCase {
 		assertEquals(4, mOutput.bellsRung);
 	}
 
-	public void testAutomargins() throws UnsupportedEncodingException {
+	public void testAutoMargins() {
 		withTerminalSized(3, 3).enterString("abc").assertLinesAre("abc", "   ", "   ").assertCursorAt(0, 2);
 		enterString("d").assertLinesAre("abc", "d  ", "   ").assertCursorAt(1, 1);
 

--- a/terminal-emulator/src/test/java/com/termux/terminal/TerminalTestCase.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/TerminalTestCase.java
@@ -1,5 +1,7 @@
 package com.termux.terminal;
 
+import androidx.annotation.NonNull;
+
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
 
@@ -12,6 +14,9 @@ import java.util.Objects;
 import java.util.Set;
 
 public abstract class TerminalTestCase extends TestCase {
+
+    public static final int INITIAL_CELL_WIDTH_PIXELS = 13;
+    public static final int INITIAL_CELL_HEIGHT_PIXELS = 15;
 
 	public static class MockTerminalOutput extends TerminalOutput {
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -80,7 +85,8 @@ public abstract class TerminalTestCase extends TestCase {
 			return Objects.hash(oldTitle, newTitle);
 		}
 
-		@Override
+		@NonNull
+        @Override
 		public String toString() {
 			return "ChangedTitle[oldTitle=" + oldTitle + ", newTitle=" + newTitle + "]";
 		}
@@ -108,7 +114,7 @@ public abstract class TerminalTestCase extends TestCase {
 
 	protected TerminalTestCase withTerminalSized(int columns, int rows) {
 	    // The tests aren't currently using the client, so a null client will suffice, a dummy client should be implemented if needed
-		mTerminal = new TerminalEmulator(mOutput, columns, rows, rows * 2, null);
+		mTerminal = new TerminalEmulator(mOutput, columns, rows, INITIAL_CELL_WIDTH_PIXELS, INITIAL_CELL_HEIGHT_PIXELS, rows * 2, null);
 		return this;
 	}
 
@@ -201,7 +207,7 @@ public abstract class TerminalTestCase extends TestCase {
 	}
 
 	public TerminalTestCase resize(int cols, int rows) {
-		mTerminal.resize(cols, rows);
+		mTerminal.resize(cols, rows, INITIAL_CELL_WIDTH_PIXELS, INITIAL_CELL_HEIGHT_PIXELS);
 		assertInvariants();
 		return this;
 	}

--- a/terminal-emulator/src/test/java/com/termux/terminal/UnicodeInputTest.java
+++ b/terminal-emulator/src/test/java/com/termux/terminal/UnicodeInputTest.java
@@ -4,7 +4,7 @@ import java.io.UnsupportedEncodingException;
 
 public class UnicodeInputTest extends TerminalTestCase {
 
-	public void testIllFormedUtf8SuccessorByteNotConsumed() throws Exception {
+	public void testIllFormedUtf8SuccessorByteNotConsumed() {
 		// The Unicode Standard Version 6.2 – Core Specification (http://www.unicode.org/versions/Unicode6.2.0/ch03.pdf):
 		// "If the converter encounters an ill-formed UTF-8 code unit sequence which starts with a valid first byte, but which does not
 		// continue with valid successor bytes (see Table 3-7), it must not consume the successor bytes as part of the ill-formed
@@ -55,7 +55,7 @@ public class UnicodeInputTest extends TerminalTestCase {
 		// assertLinesAre("\uFFFD\uFFFDa  ", "     ");
 	}
 
-	public void testUnassignedCodePoint() throws UnsupportedEncodingException {
+	public void testUnassignedCodePoint() {
 		withTerminalSized(3, 3);
 		// UTF-8 for U+C2541, an unassigned code point:
 		byte[] b = new byte[]{(byte) 0xf3, (byte) 0x82, (byte) 0x95, (byte) 0x81};
@@ -74,11 +74,11 @@ public class UnicodeInputTest extends TerminalTestCase {
 		mTerminal.append(b, b.length);
 	}
 
-	public void testSimpleCombining() throws Exception {
+	public void testSimpleCombining() {
 		withTerminalSized(3, 2).enterString(" a\u0302 ").assertLinesAre(" a\u0302 ", "   ");
 	}
 
-	public void testCombiningCharacterInFirstColumn() throws Exception {
+	public void testCombiningCharacterInFirstColumn() {
 		withTerminalSized(5, 3).enterString("test\r\nhi\r\n").assertLinesAre("test ", "hi   ", "     ");
 
 		// U+0302 is COMBINING CIRCUMFLEX ACCENT. Test case from mosh (http://mosh.mit.edu/).
@@ -86,20 +86,20 @@ public class UnicodeInputTest extends TerminalTestCase {
 		assertLinesAre("test ", "abc  ", " \u0302    ", "def  ", "     ");
 	}
 
-	public void testCombiningCharacterInLastColumn() throws Exception {
+	public void testCombiningCharacterInLastColumn() {
 		withTerminalSized(3, 2).enterString("  a\u0302").assertLinesAre("  a\u0302", "   ");
 		withTerminalSized(3, 2).enterString("  à̲").assertLinesAre("  à̲", "   ");
 		withTerminalSized(3, 2).enterString("Aà̲F").assertLinesAre("Aà̲F", "   ");
 	}
 
-	public void testWideCharacterInLastColumn() throws Exception {
+	public void testWideCharacterInLastColumn() {
 		withTerminalSized(3, 2).enterString("  枝\u0302").assertLinesAre("   ", "枝\u0302 ");
 
 		withTerminalSized(3, 2).enterString(" 枝").assertLinesAre(" 枝", "   ").assertCursorAt(0, 2);
 		enterString("a").assertLinesAre(" 枝", "a  ");
 	}
 
-	public void testWideCharacterDeletion() throws Exception {
+	public void testWideCharacterDeletion() {
 		// CSI Ps D Cursor Backward Ps Times
 		withTerminalSized(3, 2).enterString("枝\033[Da").assertLinesAre(" a ", "   ");
 		withTerminalSized(3, 2).enterString("枝\033[2Da").assertLinesAre("a  ", "   ");
@@ -118,14 +118,14 @@ public class UnicodeInputTest extends TerminalTestCase {
 		withTerminalSized(3, 2).enterString("abc\033[3D枝").assertLinesAre("枝c", "   ");
 	}
 
-	public void testOverlongUtf8Encoding() throws Exception {
+	public void testOverlongUtf8Encoding() {
 		// U+0020 should be encoded as 0x20, 0xc0 0xa0 is an overlong encoding
 		// so should be replaced with the replacement char U+FFFD.
 		withTerminalSized(5, 5).mTerminal.append(new byte[]{(byte) 0xc0, (byte) 0xa0, 'Y'}, 3);
 		assertLineIs(0, "\uFFFDY   ");
 	}
 
-	public void testWideCharacterWithoutWrapping() throws Exception {
+	public void testWideCharacterWithoutWrapping() {
 		// With wraparound disabled. The behaviour when a wide character is output with cursor in
 		// the last column when autowrap is disabled is not obvious, but we expect the wide
 		// character to be ignored here.
@@ -133,7 +133,7 @@ public class UnicodeInputTest extends TerminalTestCase {
 		enterString("a枝").assertLinesAre("枝a", "   ", "   ");
 	}
 
-    public void testManyZeroWidths() throws Exception {
+    public void testManyZeroWidths() {
         var input = new StringBuilder("a");
         for (var i = 0; i < 1000; i++) {
             input.append("\u0302");


### PR DESCRIPTION
Implement the following CSI escape sequences from
https://invisible-island.net/xterm/ctlseqs/ctlseqs.html:

> CSI Ps ; Ps ; Ps t
> [..]
>    Ps = 1 4  ⇒  Report xterm text area size in pixels.
>    Result is CSI  4 ;  height ;  width t
> [..]
>    Ps = 1 6  ⇒  Report xterm character cell size in pixels.
>    Result is CSI  6 ;  height ;  width t

Also stub android.util.Base64 in terminal tests and removed unused throw statements.

Based on work in https://github.com/termux/termux-app/pull/2973 by @MatanZ - thanks!