### PR TITLE
Changed: Make Termux:X11 visible using <queries>

### DIFF
--- a/termux-app/src/main/AndroidManifest.xml
+++ b/termux-app/src/main/AndroidManifest.xml
@@ -35,6 +35,12 @@
     <!-- See https://developer.android.com/training/data-storage/manage-all-files -->
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" tools:ignore="ScopedStorage" />
 
+    <queries>
+        <!-- See https://developer.android.com/training/package-visibility
+             and https://github.com/termux/termux-x11/blob/master/shell-loader/src/main/java/com/termux/x11/Loader.java -->
+        <package android:name="com.termux.x11"/>
+    </queries>
+
     <application
         android:dataExtractionRules="@xml/backup"
         android:enableOnBackInvokedCallback="true"


### PR DESCRIPTION
The [Loader.java](https://github.com/termux/termux-x11/blob/master/shell-loader/src/main/java/com/termux/x11/Loader.java) in `Termux:X11` needs to be able to query information about the installed `Termux:X11` app.

With a target SDK of Android 11 or later that requires the [<queries> manifest element](https://developer.android.com/training/package-visibility).