### PR TITLE
Fix TermuxFileReceiverActivity

### DIFF
--- a/termux-app/src/main/java/com/termux/app/TermuxAppShell.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxAppShell.java
@@ -64,8 +64,9 @@ public final class TermuxAppShell {
     }
 
     public static @Nullable TermuxAppShell execute(File executable,
-                                                   String[] arguments,
-                                                   @NonNull final TermuxService termuxService) {
+                                                   @NonNull String[] arguments,
+                                                   @NonNull final TermuxService termuxService,
+                                                   @Nullable String workingDirectoryString) {
         var command = TermuxShellUtils.setupShellCommandArguments(executable, arguments, false);
         var environmentArray = TermuxShellUtils.setupEnvironment(false);
         final Process process;
@@ -74,8 +75,8 @@ public final class TermuxAppShell {
             runtimeExecArgs[0] = command.executablePath;
             // TODO: Skipping first arg such as "sh" since it's not possible using the java exec() api to set it:
             System.arraycopy(command.arguments, 1, runtimeExecArgs, 1, command.arguments.length - 1);
-            Log.e("termux", "TermuxAppShell::execute: runtimeExecArgs=" + Arrays.toString(runtimeExecArgs));
-            process = Runtime.getRuntime().exec(runtimeExecArgs, environmentArray, new File(TermuxConstants.HOME_PATH));
+            var workingDirectory = new File(workingDirectoryString == null ? TermuxConstants.HOME_PATH : workingDirectoryString);
+            process = Runtime.getRuntime().exec(runtimeExecArgs, environmentArray, workingDirectory);
         } catch (IOException e) {
             Log.e(TermuxConstants.LOG_TAG, "Error executing task", e);
             return null;

--- a/termux-app/src/main/java/com/termux/app/TermuxService.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxService.java
@@ -256,19 +256,20 @@ public final class TermuxService extends Service {
             arguments = new String[0];
         }
 
+        var workingDirectory = intent.getStringExtra(TERMUX_EXECUTE_WORKDIR);
+
         if (inBackground) {
-            executeBackgroundTask(executable, arguments);
+            executeBackgroundTask(executable, arguments, workingDirectory);
         } else {
             String stdin = null;
-            String workingDirectory = null;
             boolean isFailsafe = false;
             String sessionName = null;
             createTermuxSession(executable, arguments, stdin, workingDirectory, isFailsafe, sessionName);
         }
     }
 
-    private void executeBackgroundTask(File executable, String[] arguments) {
-        var newTermuxTask = TermuxAppShell.execute(executable, arguments, this);
+    private void executeBackgroundTask(File executable, @NonNull String[] arguments, @Nullable String workingDirectory) {
+        var newTermuxTask = TermuxAppShell.execute(executable, arguments, this, workingDirectory);
         if (newTermuxTask != null) {
             mTermuxTasks.add(newTermuxTask);
             updateNotification();
@@ -286,7 +287,7 @@ public final class TermuxService extends Service {
      * Currently called by {@link TermuxTerminalSessionActivityClient#addNewSession(boolean, String)} to add a new {@link TerminalSession}.
      */
     public @NonNull TerminalSession createTermuxSession(File executable,
-                                                        String[] arguments,
+                                                        @NonNull String[] arguments,
                                                         String stdin,
                                                         @Nullable String workingDirectory,
                                                         boolean isFailSafe,
@@ -356,6 +357,7 @@ public final class TermuxService extends Service {
             sessionClient,
             executable,
             workingDirectory,
+            arguments,
             isFailSafe
         );
 
@@ -550,7 +552,7 @@ public final class TermuxService extends Service {
                 if (!scriptFile.canExecute() && !scriptFile.setExecutable(true)) {
                     Log.e(TermuxConstants.LOG_TAG, "Cannot set file executable: " + scriptFile.getAbsolutePath());
                 }
-                executeBackgroundTask(scriptFile, new String[0]);
+                executeBackgroundTask(scriptFile, new String[0], null);
             }
         }
     }

--- a/termux-app/src/main/java/com/termux/app/TermuxShellUtils.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxShellUtils.java
@@ -164,6 +164,7 @@ public class TermuxShellUtils {
     public static @NonNull TerminalSession executeTerminalSession(@NonNull TerminalSessionClient terminalSessionClient,
                                                                   @Nullable File executable,
                                                                   @Nullable String workingDirectory,
+                                                                  @Nullable String[] arguments,
                                                                   boolean failSafe) {
         boolean isLoginShell = executable == null;
 
@@ -185,7 +186,9 @@ public class TermuxShellUtils {
             executable = new File("/system/bin/sh");
         }
 
-        String[] arguments = new String[0];
+        if (arguments == null) {
+            arguments = new String[0];
+        }
         TermuxShellUtils.ExecuteCommand command = TermuxShellUtils.setupShellCommandArguments(executable, arguments, isLoginShell);
 
         var environmentArray = TermuxShellUtils.setupEnvironment(failSafe);

--- a/termux-app/src/main/java/com/termux/app/TermuxTerminalSessionActivityClient.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxTerminalSessionActivityClient.java
@@ -3,6 +3,7 @@ package com.termux.app;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.media.AudioAttributes;
@@ -383,7 +384,7 @@ public final class TermuxTerminalSessionActivityClient implements TerminalSessio
         sessionToRename.mSessionName = text;
     }
 
-    public void addNewSession(boolean isFailSafe, String sessionName, File executable) {
+    public void addNewSession(boolean isFailSafe, String sessionName, File executable, @Nullable Intent sessionIntent) {
         var service = mActivity.getTermuxService();
         if (service == null) {
             return;
@@ -400,8 +401,15 @@ public final class TermuxTerminalSessionActivityClient implements TerminalSessio
                 sessionName = "Failsafe";
             }
             var currentSession = mActivity.getCurrentSession();
-            var workingDirectory = currentSession == null ? TermuxConstants.HOME_PATH : currentSession.getCwd();
-            var newTermuxSession = service.createTermuxSession(executable, null, null, workingDirectory, isFailSafe, sessionName);
+            var workingDirectory = (sessionIntent == null) ? null : sessionIntent.getStringExtra(TermuxService.TERMUX_EXECUTE_WORKDIR);
+            var arguments = (sessionIntent == null) ? null : sessionIntent.getStringArrayExtra(TermuxService.TERMUX_EXECUTE_EXTRA_ARGUMENTS);
+            if (arguments == null) {
+                arguments = new String[0];
+            }
+            if (workingDirectory == null) {
+                workingDirectory = currentSession == null ? TermuxConstants.HOME_PATH : currentSession.getCwd();
+            }
+            var newTermuxSession = service.createTermuxSession(executable, arguments, null, workingDirectory, isFailSafe, sessionName);
             setCurrentSession(newTermuxSession);
             mActivity.getDrawer().closeDrawers();
         }

--- a/termux-app/src/main/java/com/termux/app/TermuxTerminalViewClient.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxTerminalViewClient.java
@@ -119,7 +119,7 @@ public final class TermuxTerminalViewClient implements TerminalViewClient {
             } else if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
                 mActivity.getDrawer().closeDrawers();
             } else if (unicodeChar == 'c'/* create */) {
-                mTermuxTerminalSessionActivityClient.addNewSession(false, null, null);
+                mTermuxTerminalSessionActivityClient.addNewSession(false, null, null, null);
             } else if (unicodeChar == 'k'/* keyboard */) {
                 onToggleSoftKeyboardRequest();
             } else if (unicodeChar == 'm'/* menu */) {


### PR DESCRIPTION
Since we don't have the `SYSTEM_ALERT_WINDOW` granted on Google Play (and it's good to manage without that if possible) we need to start the Termux activity explicitly, instead of going through the Termux service.

Also do not do I/O on the UI thread when receiving files to avoid ANR (Activity Not Responding) errors when receiving files and I/O is slow (due to big files, slow content providers, or slow writes to storage).