### PR TITLE
Request ACCESS_LOCAL_NETWORK permission for local network access (#1)

### DIFF
--- a/termux-app/src/main/AndroidManifest.xml
+++ b/termux-app/src/main/AndroidManifest.xml
@@ -25,6 +25,8 @@
     <permission android:name="com.termux.sharedfile.READ_WRITE" android:protectionLevel="signature" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- See https://developer.android.com/privacy-and-security/local-network-permission -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/termux-app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxActivity.java
@@ -326,6 +326,16 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
                 Manifest.permission.POST_NOTIFICATIONS
             );
         }
+
+        // Starting with Android 17, apps targeting SDK 37+ have local network access
+        // (e.g. ping, ssh to LAN devices) blocked unless this runtime permission is granted.
+        // See https://developer.android.com/privacy-and-security/local-network-permission
+        if (Build.VERSION.SDK_INT >= 37) {
+            TermuxPermissionUtils.requestPermissions(this,
+                TermuxPermissionUtils.REQUEST_ACCESS_LOCAL_NETWORK,
+                TermuxPermissionUtils.PERMISSION_ACCESS_LOCAL_NETWORK
+            );
+        }
     }
 
     @Override

--- a/termux-app/src/main/java/com/termux/app/TermuxPermissionUtils.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxPermissionUtils.java
@@ -21,6 +21,14 @@ public class TermuxPermissionUtils {
 
     public static final int REQUEST_DISABLE_BATTERY_OPTIMIZATIONS = 2001;
     public static final int REQUEST_POST_NOTIFICATIONS = 2002;
+    public static final int REQUEST_ACCESS_LOCAL_NETWORK = 2003;
+
+    /**
+     * See https://developer.android.com/privacy-and-security/local-network-permission
+     * Not yet part of {@link android.Manifest.permission} in all compile SDKs, so the
+     * literal string is used instead of a compile-time constant.
+     */
+    public static final String PERMISSION_ACCESS_LOCAL_NETWORK = "android.permission.ACCESS_LOCAL_NETWORK";
 
     /**
      * Check which permissions that has not been granted.


### PR DESCRIPTION
Android 17 blocks local network access (ping, ssh, etc. to LAN devices) by default for apps targeting SDK 37+ unless they declare and request the new ACCESS_LOCAL_NETWORK runtime permission.

Fixes #115


Claude-Session: https://claude.ai/code/session_01LSHozoZDzTriedTdJJX8q1