### PR TITLE
fix(termux-app): request ACCESS_LOCAL_NETWORK for Android 17

### DIFF
--- a/termux-app/src/main/AndroidManifest.xml
+++ b/termux-app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
     <permission android:name="com.termux.sharedfile.READ_WRITE" android:protectionLevel="signature" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Android 17 (API 37) makes Local Network Protection mandatory.
+         Without this runtime permission the OS blocks all LAN traffic.
+         See https://developer.android.com/privacy-and-security/local-network-permission -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/termux-app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxActivity.java
@@ -326,6 +326,16 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
                 Manifest.permission.POST_NOTIFICATIONS
             );
         }
+
+        // Android 17 (API 37) enforces Local Network Protection: without ACCESS_LOCAL_NETWORK the
+        // OS blocks all LAN traffic, making sshd and other servers unreachable. The permission
+        // exists from API 36 but is only enforced at 37+, so request it there.
+        if (Build.VERSION.SDK_INT >= 37) {
+            TermuxPermissionUtils.requestPermissions(this,
+                TermuxPermissionUtils.REQUEST_ACCESS_LOCAL_NETWORK,
+                Manifest.permission.ACCESS_LOCAL_NETWORK
+            );
+        }
     }
 
     @Override

--- a/termux-app/src/main/java/com/termux/app/TermuxPermissionUtils.java
+++ b/termux-app/src/main/java/com/termux/app/TermuxPermissionUtils.java
@@ -21,6 +21,7 @@ public class TermuxPermissionUtils {
 
     public static final int REQUEST_DISABLE_BATTERY_OPTIMIZATIONS = 2001;
     public static final int REQUEST_POST_NOTIFICATIONS = 2002;
+    public static final int REQUEST_ACCESS_LOCAL_NETWORK = 2003;
 
     /**
      * Check which permissions that has not been granted.


### PR DESCRIPTION
## Problem

Android 17 (API 37) enforces [Local Network Protection](https://developer.android.com/privacy-and-security/local-network-permission) for apps targeting API 37+: all LAN traffic is gated behind the runtime `ACCESS_LOCAL_NETWORK` permission. Termux never declared it, so on Android 17 the OS silently blocks connections.

Fixes termux-play-store/termux-issues#1389.

## Change

- Declare `android.permission.ACCESS_LOCAL_NETWORK` in the manifest.
- Request it at runtime in `TermuxActivity.onStart()`, guarded by `SDK_INT >= 37` (the permission exists from API 36 but is only opt-in there; it is enforced at 37+).

## Notes

- Users on Android 17 will see a one-time "Nearby devices" permission prompt when they open the app; granting it restores LAN access.